### PR TITLE
Modify for centos

### DIFF
--- a/DockerResources/lua/sample_disque_client.lua
+++ b/DockerResources/lua/sample_disque_client.lua
@@ -65,7 +65,7 @@ if false then
 		-- no key found.
 		ngx.log(ngx.ERR, "connection:", CONNECTION_ID, " failed to authenticate. no token found in kvs.")
 
-		-- 切断
+		-- close 
 		redisConn:close()
 		ngx.exit(200)
 		return
@@ -73,7 +73,7 @@ if false then
 		-- no value found.
 		ngx.log(ngx.ERR, "connection:", CONNECTION_ID, " failed to authenticate. token is nil.")
 
-		-- 切断
+		-- close 
 		redisConn:close()
 		ngx.exit(200)
 		return
@@ -82,10 +82,10 @@ if false then
 	-- delete got key.
 	local ok, err = redisConn:del(token)
 
-	-- 切断
+	-- close
 	redisConn:close()
 
-	-- 変数にセット、パラメータとして渡す。
+	-- set parameter
 	user_data = res
 else
 	user_data = token

--- a/DockerResources/lua/sample_disque_client.lua
+++ b/DockerResources/lua/sample_disque_client.lua
@@ -88,11 +88,13 @@ if false then
 	-- set parameter
 	user_data = res
 else
-	user_data = token
-	CONNECTION_ID = token
+	user_data = ""
+	if token ~= "" then
+		CONNECTION_ID = token
+	end
 end
 
--- ngx.log(ngx.ERR, "connection:", CONNECTION_ID, " user_data:", user_data)
+ngx.log(ngx.ERR, "connection:", CONNECTION_ID, " user_data:", user_data)
 
 
 

--- a/DockerResources/nginx.conf
+++ b/DockerResources/nginx.conf
@@ -66,7 +66,6 @@ http {
 }
 
 stream {
-    # goでのudpサーバを置き、クライアントからの通信には必要情報の返却、サーバ内からのunix domain socketでの通信をクライアントへと転送する。
     upstream stream_backend {
         server 127.0.0.1:8081;
     }
@@ -74,7 +73,6 @@ stream {
     server {
         listen 8080 udp;
 
-        # addrとportを返す or 別のものを返す(キー)
         # return $remote_addr:$remote_port;
 
         proxy_pass stream_backend;

--- a/centos.dockerfile
+++ b/centos.dockerfile
@@ -1,13 +1,15 @@
-FROM centos
+FROM centos:centos7
 
 ENV NGINX_VERSION 1.13.6
-ENV LUAJIT_VERSION 2.0.5
+ENV LUAJIT_VERSION 2.1.0-beta3
 ENV NGINX_DEVEL_KIT_VERSION v0.3.0
 ENV NGINX_LUAJIT_VERSION v0.10.11
 
 # RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
 
 # RUN sh -c 'echo -e "[packages-microsoft-com-prod]\nname=packages-microsoft-com-prod \nbaseurl=https://packages.microsoft.com/yumrepos/microsoft-rhel7.3-prod\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/dotnetdev.repo'
+
+RUN yum -y install epel-release
 
 # ready tools.
 RUN yum -y install \


### PR DESCRIPTION
・日本語のコメントを英語に、又は削除しました。
・Redisの認証機構を使用しない場合、sample_disque_client.luaが動作しない（CONNECTION_IDを自分で渡さないといけない）状態だったので対処。
・dockerfileが、そのままではビルド出来なかったので修正。